### PR TITLE
fix #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dataset - https://github.com/amith-vp/Kerala-Private-Bus-Timing (Converted RTI Detailing published by MVD)
 
-## GET /api/v1/schedules/:departure/:destination
+## GET /api/v1/schedules
 
 Returns a list of trips between two stations, optionally filtered by departure time and optionally excluding stations before the departure station and after the destination station.
 
@@ -28,7 +28,7 @@ A JSON array of trips. Each trip is an object with the following properties:
 
 Request:
 
-https://busapi.amithv.xyz/api/v1/schedules/high_court_junction/ernakulam_south?time=12:00
+https://busapi.amithv.xyz/api/v1/schedules?departure=high court junction&destination=ernakulam south&time=12:00
 
 Response:
 
@@ -151,6 +151,6 @@ Now, you should be able to access the application on your local machine.
 You can access the API from the following URL:
 
 ```
-http://localhost:3000/api/v1/schedules/aluva/kakkanad
+http://localhost:3000/api/v1/schedules?departure=aluva&destination=kakkanad
 ```
 

--- a/app/controllers/api/v1/schedules_controller.rb
+++ b/app/controllers/api/v1/schedules_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::SchedulesController < ApplicationController
   def index
     
     # convert the dep and des station names to uppercase and replace underscores with spaces
-    departure_station = params[:departure]&.upcase&.gsub('_', ' ')
-    destination_station = params[:destination]&.upcase&.gsub('_', ' ')
+    departure_station = params[:departure]&.upcase
+    destination_station = params[:destination]&.upcase
     
     time = params[:time].present? ? Time.parse(params[:time]) : nil
     exclude = params[:restrict]&.downcase == 'true'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      get 'schedules/:departure/:destination', to: 'schedules#index'
+      resources :schedules, only: :index
       resources :search, only: [:index]
     end
   end


### PR DESCRIPTION
1. query parameters instead of dynamic route 

    `schedules/:departure/:destination` to `schedules?destination=&departure=`

2. Removed support for `_` replacement

3. Updated documentation